### PR TITLE
Changes for the authorize url to use the popup display flag

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -7,7 +7,8 @@ module OmniAuth
       
       option :client_options, {
         :site => 'https://graph.facebook.com',
-        :token_url => '/oauth/access_token'
+        :token_url => '/oauth/access_token',
+        :authorize_url => "https://graph.facebook.com/oauth/authorize?display=popup"
       }
 
       option :token_params, {


### PR DESCRIPTION
This allows the facebook oauth mechanism to display a "popup" window by default instead of taking the full screen.  
