### PR TITLE
fix ten_mins_from_now calculation

### DIFF
--- a/spec/omniauth/strategies/facebook_spec.rb
+++ b/spec/omniauth/strategies/facebook_spec.rb
@@ -219,7 +219,7 @@ describe OmniAuth::Strategies::Facebook do
     end
     
     it 'returns the refresh token and expiry time when expiring' do
-      ten_mins_from_now = (Time.now + 360).to_i
+      ten_mins_from_now = (Time.now + 600).to_i
       @access_token.stub(:expires?) { true }
       @access_token.stub(:refresh_token) { '321' }
       @access_token.stub(:expires_at) { ten_mins_from_now }


### PR DESCRIPTION
Time.now + 360 is 6 mins from now 
$ irb

> > now = Time.now
> > => 2011-11-15 14:20:45 +0200
> > now + 360
> > => 2011-11-15 14:26:45 +0200
> > now + 600
> > => 2011-11-15 14:30:45 +0200
