### PR TITLE
Add callback_url option

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -57,6 +57,14 @@ module OmniAuth
         @raw_info ||= access_token.get('/me').parsed
       end
 
+      def callback_url
+        if options.authorize_options.respond_to? :callback_url
+          options.authorize_options.callback_url
+        else
+          super
+        end
+      end
+
       def build_access_token
         super.tap do |token|
           token.options.merge!(access_token_options)

--- a/spec/omniauth/strategies/facebook_spec.rb
+++ b/spec/omniauth/strategies/facebook_spec.rb
@@ -29,6 +29,21 @@ describe OmniAuth::Strategies::Facebook do
     end
   end
 
+  describe '#callback_url' do
+    it "returns value from #authorize_options" do
+      url = 'http://auth.myapp.com/auth/fb/callback'
+      @options = {:authorize_options => { :callback_url => url }}
+      subject.callback_url.should == url
+    end
+
+    it " callback_url from request" do
+      url_base = 'http://auth.request.com'
+      @request.stub(:url){ url_base + "/page/path" }
+      subject.stub(:script_name) { "" } # to not depend from Rack env
+      subject.callback_url.should == url_base + "/auth/facebook/callback"
+    end
+  end
+
   describe '#authorize_params' do
     it 'includes default scope for email and offline access' do
       subject.authorize_params.should be_a(Hash)


### PR DESCRIPTION
Sometimes we need to pass callback url to match FB application security configuration.

``` ruby
    provider :facebook, cfg['app_id'], cfg['app_secret'], {
      :authorize_options => { :callback_url => cfg['callback_url'] }
    }
```
