### PR TITLE
fix callback_url option handling to not rewrite authentication_options array

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -22,7 +22,8 @@ module OmniAuth
       }
       
       option :authorize_options, [:scope, :display]
-      
+      option :callback_url
+
       uid { raw_info['id'] }
       
       info do
@@ -73,11 +74,7 @@ module OmniAuth
         if @authorization_code_from_cookie
           ''
         else
-          if options.authorize_options.respond_to?(:callback_url)
-            options.authorize_options.callback_url
-          else
-            super
-          end
+          options.callback_url || super
         end
       end
 

--- a/spec/omniauth/strategies/facebook_spec.rb
+++ b/spec/omniauth/strategies/facebook_spec.rb
@@ -39,7 +39,7 @@ describe OmniAuth::Strategies::Facebook do
   describe '#callback_url' do
     it "returns value from #authorize_options" do
       url = 'http://auth.myapp.com/auth/fb/callback'
-      @options = { :authorize_options => { :callback_url => url } }
+      @options = { :callback_url => url }
       subject.callback_url.should eq(url)
     end
 


### PR DESCRIPTION
In previous implementation it rewrites authentication_options = [:scope, :display]
