### PR TITLE
Add 'state' to authorization params.

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -88,6 +88,7 @@ module OmniAuth
       def authorize_params
         super.tap do |params|
           params.merge!(:display => request.params['display']) if request.params['display']
+          params.merge!(:state => request.params['state']) if request.params['state']
           params[:scope] ||= DEFAULT_SCOPE
         end
       end

--- a/spec/omniauth/strategies/facebook_spec.rb
+++ b/spec/omniauth/strategies/facebook_spec.rb
@@ -62,6 +62,12 @@ describe OmniAuth::Strategies::Facebook do
       subject.authorize_params.should be_a(Hash)
       subject.authorize_params[:display].should eq('touch')
     end
+
+    it 'includes state parameter from request when present' do
+      @request.stub(:params) { { 'state' => 'some_state' } }
+      subject.authorize_params.should be_a(Hash)
+      subject.authorize_params[:state].should eq('some_state')
+    end
   end
 
   describe '#token_params' do


### PR DESCRIPTION
More information on https://developers.facebook.com/docs/reference/dialogs/oauth/

The facebook's implementation of OAuth, allows to pass only one special parameter wich will be passed back in the callback.

This is useful because, you can manage the server side response.

I am using it in Rails 3 app, in the "omniauth controller" for Devise. I pass "popup" as value to "state", so when I receive the callback, I can respond with a different partial than when is called "full screen".
