### PR TITLE
Add ability to specify picture size via client options

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -9,7 +9,8 @@ module OmniAuth
       
       option :client_options, {
         :site => 'https://graph.facebook.com',
-        :token_url => '/oauth/access_token'
+        :token_url => '/oauth/access_token',
+        :picture_size => 'square'
       }
 
       option :token_params, {
@@ -32,7 +33,7 @@ module OmniAuth
           'name' => raw_info['name'],
           'first_name' => raw_info['first_name'],
           'last_name' => raw_info['last_name'],
-          'image' => "http://graph.facebook.com/#{uid}/picture?type=square",
+          'image' => "http://graph.facebook.com/#{uid}/picture?type=#{options.client_options[:picture_size]}",
           'description' => raw_info['bio'],
           'urls' => {
             'Facebook' => raw_info['link'],

--- a/spec/omniauth/strategies/facebook_spec.rb
+++ b/spec/omniauth/strategies/facebook_spec.rb
@@ -31,6 +31,10 @@ describe OmniAuth::Strategies::Facebook do
       subject.client.options[:authorize_url].should eq('/oauth/authorize')
     end
 
+    it 'has correct picture size' do
+      subject.client.options[:picture_size].should eq('square')
+    end
+
     it 'has correct token url' do
       subject.client.options[:token_url].should eq('/oauth/access_token')
     end
@@ -311,6 +315,28 @@ describe OmniAuth::Strategies::Facebook do
       end
     end
   end
+
+  describe "client options" do
+
+    let(:client_options) { {} }
+
+    before do
+      @options = { :client_options => client_options }
+      subject.stub(:raw_info) { {} }
+    end
+
+    context "when picture size is small" do
+      let(:client_options) { { 'picture_size' => 'small' } }
+
+      it 'returns the small format facebook avatar url' do
+        subject.info['image'].should match /type=small/
+      end
+
+    end
+
+  end
+
+
 
 private
 


### PR DESCRIPTION
Before avatar url was hard coded to pull in the smallest possible picture from facebook (square), but facebook provides 3 other larger picture sizes (small, normal, large). You can now specify use client options to choose any of these.
