### PR TITLE
Have raw_info return an empty hash if the Facebook response returns false

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -60,7 +60,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me').parsed
+        @raw_info ||= access_token.get('/me').parsed || {}
       end
 
       def build_access_token

--- a/spec/omniauth/strategies/facebook_spec.rb
+++ b/spec/omniauth/strategies/facebook_spec.rb
@@ -258,6 +258,15 @@ describe OmniAuth::Strategies::Facebook do
       subject.raw_info.should be_a(Hash)
       subject.raw_info['ohai'].should eq('thar')
     end
+    
+    it 'returns an empty hash when the response is false' do
+      @access_token.stub(:get).with('/me') do
+        response = double('OAuth2::Response')
+        response.stub(:parsed => false)
+        response
+      end
+      subject.raw_info.should be_a(Hash)
+    end
   end
 
   describe '#credentials' do


### PR DESCRIPTION
Sometimes in a production app I've run into exceptions because we get a false value back from the Facebook me request. This handles that edge case by falling back to an empty hash.
