### PR TITLE
Bump omniauth-oauth2 dependency to v1.0.2 to include additional error handling

### DIFF
--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.0.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.0.2'
 
   s.add_development_dependency 'rspec', '~> 2.7.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
(and general mistrust of Facebook to return valid responses)

Primarily for these changes:
- [Handle socket errors](https://github.com/intridea/omniauth-oauth2/commit/a96318460accb9c0e5234845f2bc458becbde52f)
- [Require timeout, so rescue ::Timeout::Error does not cause a NameError](https://github.com/intridea/omniauth-oauth2/commit/0e32dcecdbca7d8f99064559f654d3b6d695ee93)
