### PR TITLE
wrong link in readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also pass through a `state` param which will be passed along to the call
 
 ### Custom Callback URL/Path
 
-You can set a custom `callback_url` or `callback_path` option to override the default value. See [OmniAuth::Strategy#callback_url](https://github.com/intridea/omniauth/blob/master/lib/omniauth/strategy.rb#L387) for more details on the default.
+You can set a custom `callback_url` or `callback_path` option to override the default value. See [OmniAuth::Strategy#callback_url](https://github.com/intridea/omniauth/blob/master/lib/omniauth/strategy.rb#L411) for more details on the default.
 
 ## Auth Hash
 


### PR DESCRIPTION
Updated a link in the readme to point to def callback_url instead of query_string
