### PR TITLE
Add support of the :auth_type option to :authorize_options

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -24,7 +24,7 @@ module OmniAuth
         :param_name => 'access_token'
       }
 
-      option :authorize_options, [:scope, :display]
+      option :authorize_options, [:scope, :display, :auth_type]
 
       uid { raw_info['id'] }
 


### PR DESCRIPTION
http://developers.facebook.com/docs/authentication/reauthentication/
auth_type: this parameter specifies the requested authentication features (as a comma-separated list). Valid options are:

```
https - checks for the presence of the secure cookie and asks for re-authentication if it is not present
reauthenticate - asks the user to re-authenticate unconditionally
```
