### PR TITLE
ability to specify auth_type per-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ end
 
 ### Per-Request Options
 
-If you want to set the `display` format or `scope` on a per-request basis, you can just pass it to the OmniAuth request phase URL, for example: `/auth/facebook?display=popup` or `/auth/facebook?scope=email`.
+If you want to set the `display` format, `auth_type`, or `scope` on a per-request basis, you can just pass it to the OmniAuth request phase URL, for example: `/auth/facebook?display=popup` or `/auth/facebook?scope=email`.
 
 You can also pass through a `state` param which will be passed along to the callback url.
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -112,7 +112,7 @@ module OmniAuth
       end
 
       ##
-      # You can pass +display+, +state+ or +scope+ params to the auth request, if
+      # You can pass +display+, +state+, +scope+, or +auth_type+ params to the auth request, if
       # you need to set them dynamically. You can also set these options
       # in the OmniAuth config :authorize_params option.
       #
@@ -120,7 +120,7 @@ module OmniAuth
       #
       def authorize_params
         super.tap do |params|
-          %w[display state scope].each do |v|
+          %w[display state scope auth_type].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -62,6 +62,12 @@ class AuthorizeParamsTest < StrategyTestCase
     assert_equal 'some_state', strategy.authorize_params[:state]
   end
 
+  test 'includes auth_type parameter from request when present' do
+    @request.stubs(:params).returns({ 'auth_type' => 'reauthenticate' })
+    assert strategy.authorize_params.is_a?(Hash)
+    assert_equal 'reauthenticate', strategy.authorize_params[:auth_type]
+  end
+
   test 'overrides default scope with parameter passed from request' do
     @request.stubs(:params).returns({ 'scope' => 'email' })
     assert strategy.authorize_params.is_a?(Hash)


### PR DESCRIPTION
First of all, thanks for open-sourcing the omniauth gems! They've been very helpful.

So, here's why I want to merge this functionality: My API has several consumers. Some consumers want to force facebook reauthentication with every login, but others do not want the default behavior to change. It would be great to give them the power to override the auth_type.
