### PR TITLE
Fix canvas server side authentication with signed_request

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -12,6 +12,7 @@ module OmniAuth
 
       option :client_options, {
         :site => 'https://graph.facebook.com',
+        :authorize_url => "https://www.facebook.com/dialog/oauth",
         :token_url => '/oauth/access_token'
       }
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -13,7 +13,7 @@ class ClientTest < StrategyTestCase
   end
 
   test 'has correct authorize url' do
-    assert_equal '/oauth/authorize', strategy.client.options[:authorize_url]
+    assert_equal 'https://www.facebook.com/dialog/oauth', strategy.client.options[:authorize_url]
   end
 
   test 'has correct token url' do


### PR DESCRIPTION
When trying to authorize using a signed_request via a canvas page submit, simply shuffling the state along to the connect_phase doesn't pass oauth2's built in csrf protection. Resulting in an invalid credentials error.

`authorize_params` already deals with this correctly and it seems like all the params that it handles should be shuffled so we can just merge those with the signed_request param to get full support of the authentication strategy.
