### PR TITLE
Stubs request #ssl?

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,6 +36,7 @@ class StrategyTestCase < TestCase
     @request.stubs(:params).returns({})
     @request.stubs(:cookies).returns({})
     @request.stubs(:env).returns({})
+    @request.stubs(:ssl?).returns(false)
 
     @client_id = '123'
     @client_secret = '53cr3tz'


### PR DESCRIPTION
I had to do this to get the tests on master (13c1eca2aedacc5791c5d99ca74053a240a68b6a) to pass. Omniauth was calling `ssl?` on the request object.
