### PR TITLE
Fixes image url test

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -121,7 +121,13 @@ class InfoTest < StrategyTestCase
     @options = { :image_size => { :width => 123, :height => 987 } }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'http://graph.facebook.com/321/picture?width=123&height=987', strategy.info['image']
+    image_url = strategy.info['image']
+    path, query = image_url.split("?")
+    query_params = Hash[*query.split("&").map {|pair| pair.split("=") }.flatten]
+
+    assert_equal 'http://graph.facebook.com/321/picture', path
+    assert_equal '123', query_params['width']
+    assert_equal '987', query_params['height']
   end
 end
 


### PR DESCRIPTION
On Ruby 1.8.7 the order of hash key-value pairs is not guaranteed.

For example issue #100 is failing because of this problem (https://travis-ci.org/mkdynamic/omniauth-facebook/builds/4568421).
