### PR TITLE
Adds info_fields option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can configure several options, which you pass in to the `provider` method vi
 Valid values are `https` (checks for the presence of the secure cookie and asks for re-authentication if it is not present), and `reauthenticate` (asks the user to re-authenticate unconditionally). Default is `nil`.
 * `secure_image_url`: Set to `true` to use https for the avatar image url returned in the auth hash. Default is `false`.
 * `image_size`: Set the size for the returned image url in the auth hash. Valid options include `square` (50x50), `small` (50 pixels wide, variable height), `normal` (100 pixels wide, variable height), or `large` (about 200 pixels wide, variable height). Additionally, you can request a picture of a specific size by setting this option to a hash with `:width` and `:height` as keys. This will return an available profile picture closest to the requested size and requested aspect ratio. If only `:width` or `:height` is specified, we will return a picture whose width or height is closest to the requested size, respectively.
+* `info_fields`: Specify exactly which fields should be returned when getting the user's info. Value should be a comma-separated string as per https://developers.facebook.com/docs/reference/api/user/.
 
 For example, to request `email`, `user_birthday` and `read_stream` permissions and display the authentication page in a popup window:
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -54,7 +54,11 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me').parsed || {}
+        @raw_info ||= access_token.get('/me', info_options).parsed || {}
+      end
+
+      def info_options
+        options[:info_fields] ? {:params => {:fields => options[:info_fields]}} : {}
       end
 
       def build_access_token

--- a/test/test.rb
+++ b/test/test.rb
@@ -256,7 +256,7 @@ class RawInfoTest < StrategyTestCase
 
   test 'performs a GET to https://graph.facebook.com/me' do
     strategy.stubs(:access_token).returns(@access_token)
-    @access_token.expects(:get).with('/me').returns(stub_everything('OAuth2::Response'))
+    @access_token.expects(:get).with('/me', {}).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
@@ -267,7 +267,7 @@ class RawInfoTest < StrategyTestCase
     raw_response.stubs(:status).returns(200)
     raw_response.stubs(:headers).returns({'Content-Type' => 'application/json' })
     oauth2_response = OAuth2::Response.new(raw_response)
-    @access_token.stubs(:get).with('/me').returns(oauth2_response)
+    @access_token.stubs(:get).with('/me', {}).returns(oauth2_response)
     assert_kind_of Hash, strategy.raw_info
     assert_equal 'thar', strategy.raw_info['ohai']
   end
@@ -275,7 +275,7 @@ class RawInfoTest < StrategyTestCase
   test 'returns an empty hash when the response is false' do
     strategy.stubs(:access_token).returns(@access_token)
     oauth2_response = stub('OAuth2::Response', :parsed => false)
-    @access_token.stubs(:get).with('/me').returns(oauth2_response)
+    @access_token.stubs(:get).with('/me', {}).returns(oauth2_response)
     assert_kind_of Hash, strategy.raw_info
   end
 


### PR DESCRIPTION
I'm currently working on a project where we wanted to get the `age_range` of a user without having to access the API again. This is available via the same `/me` endpoint that users' info is currently being populated with, it simply requires the presence of a `fields` parameter set to a comma-separated list of field names. To solve this problem we added an `info_fields` option to the strategy which allows developers to specify exactly which information is returned:

``` ruby
provider :facebook, FB_KEY, FB_SECRET, info_fields: "first_name,age_range"
```

The same option has the added advantage of allowing developers to limit the amount of information returned for performance reasons.

If you like the way I've set this up I'll go ahead and write some tests for it.
