### PR TITLE
Fix csrf error with omniauth-oauth2 1.1 when using canvas signed_request

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -82,7 +82,10 @@ module OmniAuth
           # if we already have an access token, we can just hit the
           # callback URL directly and pass the signed request along
           params = { :signed_request => raw_signed_request }
-          params[:state] = request.params['state'] if request.params['state']
+          if state = (request.params['state'] || authorize_params.state)
+            params[:state] = state  
+          end
+
           query = Rack::Utils.build_query(params)
 
           url = callback_url

--- a/test/test.rb
+++ b/test/test.rb
@@ -455,10 +455,11 @@ class RequestPhaseWithSignedRequestTest < StrategyTestCase
     @request.stubs(:params).returns("signed_request" => @raw_signed_request)
 
     strategy.stubs(:callback_url).returns('/')
+    SecureRandom.stubs(:hex).returns("random_csrf_protection_state")
   end
 
   test 'redirects to callback passing along signed request' do
-    strategy.expects(:redirect).with("/?signed_request=#{Rack::Utils.escape(@raw_signed_request)}").once
+    strategy.expects(:redirect).with("/?signed_request=#{Rack::Utils.escape(@raw_signed_request)}&state=random_csrf_protection_state").once
     strategy.request_phase
   end
 end


### PR DESCRIPTION
... info for auth

When we hit /auth/facebook with signed_request_data and redirect directly
to /auth/facebook/callback, we need to pass along the "state" set by omniauth oauth2 CSRF protection

Like https://github.com/mkdynamic/omniauth-facebook/pull/97, but passing along only `state` parameter and fixing the tests.
