### PR TITLE
Don't try to parse the signature if it's nil

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -200,6 +200,7 @@ module OmniAuth
 
       def parse_signed_request(value)
         signature, encoded_payload = value.split('.')
+        return if signature.nil?
 
         decoded_hex_signature = base64_decode_url(signature)
         decoded_payload = MultiJson.decode(base64_decode_url(encoded_payload))

--- a/test/test.rb
+++ b/test/test.rb
@@ -439,6 +439,18 @@ module SignedRequestTests
       assert_equal @payload_from_param, strategy.send(:signed_request)
     end
   end
+
+  class EmptySignedRequestTest < TestCase
+    def setup
+      super
+      @request.stubs(:params).returns({'signed_request' => ''})
+    end
+
+    test 'empty param' do
+      assert_equal nil, strategy.send(:signed_request)
+    end
+  end
+
 end
 
 class RequestPhaseWithSignedRequestTest < StrategyTestCase


### PR DESCRIPTION
Since updating to 1.4.1 I've seen this error at our error tracking log. Sometimes the signature is nil and `base64_decode_url` was raising since it expects and string.
