### PR TITLE
Adding appsecret_proof param to requests to support secure API requests by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
   - update Facebook authorize URL to fix broken authorization (#103, @dlackty)
   - adds `info_fields` option (#109, @bloudermilk)
   - adds `locale` parameter (#133, @donbobka, @simi)
+  - add automatically `appsecret_proof` (#140, @nlsrchtr, @simi)
 
 Changes:
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -58,11 +58,15 @@ module OmniAuth
       end
 
       def info_options
-        params = ({:appsecret_proof => OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), client.secret, access_token.token)})
+        params = ({:appsecret_proof => appsecret_proof})
         params.merge!({:fields => options[:info_fields]}) if options[:info_fields]
         params.merge!({:locale => options[:locale]}) if options[:locale]
 
         { :params => params }
+      end
+
+      def appsecret_proof
+        @appsecret_proof ||= OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), client.secret, access_token.token)
       end
 
       def build_access_token

--- a/test/test.rb
+++ b/test/test.rb
@@ -246,45 +246,58 @@ class RawInfoTest < StrategyTestCase
   def setup
     super
     @access_token = stub('OAuth2::AccessToken')
+    @appsecret_proof = 'appsecret_proof'
+    @options = {:appsecret_proof => @appsecret_proof}
   end
 
   test 'performs a GET to https://graph.facebook.com/me' do
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     strategy.stubs(:access_token).returns(@access_token)
-    @access_token.expects(:get).with('/me', {}).returns(stub_everything('OAuth2::Response'))
+    params = {:params => @options}
+    @access_token.expects(:get).with('/me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
   test 'performs a GET to https://graph.facebook.com/me with locale' do
-    @options = { :locale => 'cs_CZ' }
+    @options.merge!({ :locale => 'cs_CZ' })
     strategy.stubs(:access_token).returns(@access_token)
-    @access_token.expects(:get).with('/me', {:params => {:locale => 'cs_CZ'}}).returns(stub_everything('OAuth2::Response'))
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    params = {:params => @options}
+    @access_token.expects(:get).with('/me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
   test 'performs a GET to https://graph.facebook.com/me with info_fields' do
-    @options = { :info_fields => 'about' }
+    @options.merge!({:info_fields => 'about'})
     strategy.stubs(:access_token).returns(@access_token)
-    @access_token.expects(:get).with('/me', {:params => {:fields => 'about'}}).returns(stub_everything('OAuth2::Response'))
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    params = {:params => {:appsecret_proof => @appsecret_proof, :fields => 'about'}}
+    @access_token.expects(:get).with('/me', params).returns(stub_everything('OAuth2::Response'))
     strategy.raw_info
   end
 
   test 'returns a Hash' do
     strategy.stubs(:access_token).returns(@access_token)
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     raw_response = stub('Faraday::Response')
     raw_response.stubs(:body).returns('{ "ohai": "thar" }')
     raw_response.stubs(:status).returns(200)
     raw_response.stubs(:headers).returns({'Content-Type' => 'application/json' })
     oauth2_response = OAuth2::Response.new(raw_response)
-    @access_token.stubs(:get).with('/me', {}).returns(oauth2_response)
+    params = {:params => @options}
+    @access_token.stubs(:get).with('/me', params).returns(oauth2_response)
     assert_kind_of Hash, strategy.raw_info
     assert_equal 'thar', strategy.raw_info['ohai']
   end
 
   test 'returns an empty hash when the response is false' do
     strategy.stubs(:access_token).returns(@access_token)
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     oauth2_response = stub('OAuth2::Response', :parsed => false)
-    @access_token.stubs(:get).with('/me', {}).returns(oauth2_response)
+    params = {:params => @options}
+    @access_token.stubs(:get).with('/me', params).returns(oauth2_response)
     assert_kind_of Hash, strategy.raw_info
+    assert_equal({}, strategy.raw_info)
   end
 
   test 'should not include raw_info in extras hash when skip_info is specified' do


### PR DESCRIPTION
Started in https://github.com/mkdynamic/omniauth-facebook/issues/137.
