### PR TITLE
Travis - Add Ruby 2.1.0, Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - jruby
+  - rbx
+matrix:
+  allow_failures:
+    - rvm: rbx

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'jruby-openssl', :platform => :jruby
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+end

--- a/README.md
+++ b/README.md
@@ -165,17 +165,13 @@ If you're having issue getting a long lived token with the server-side flow, mak
 
 Actively tested with the following Ruby versions:
 
+- MRI 2.1.0
 - MRI 2.0.0
 - MRI 1.9.3
 - MRI 1.9.2
 - MRI 1.8.7
-- JRuby 1.7.4
-
-*NB.* For JRuby < 1.7, you'll need to install the `jruby-openssl` gem. There's no way to automatically specify this in a Rubygem gemspec, so you need to manually add it your project's own Gemfile:
-
-```ruby
-gem 'jruby-openssl', :platform => :jruby
-```
+- JRuby 1.7.9
+- Rubinius (latest stable)
 
 ## License
 


### PR DESCRIPTION
1. Added Rubinius and 2.1.0 to Travis config.
2. Added Rubinius gems to Gemfile
