### PR TITLE
Lock upstream omniauth and omniauth-oauth2 versions temporary.

### DIFF
--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '= 1.1.1'
+  s.add_runtime_dependency 'omniauth', '= 1.1.4'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
@mkdynamic I found that some changes in upstream broke [tests](https://travis-ci.org/zizkovrb/omniauth-facebook/jobs/17388380). Until I resolve this problem, it's good idea to lock dependencies to avoid unexpected behaviour.
