### PR TITLE
Upgrade omniauth-oauth2 gem to version 1.2

### DIFF
--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
This is meant to address [CVE-2012-6134](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6134)

Please let me know if/how you'd like me to change the omniauth-facebook gem version in the gemspec.

Thanks!
