### PR TITLE
[WIP] Add verified access_token parameter authentication.

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -137,7 +137,7 @@ module OmniAuth
       def verify_access_token!(access_token)
         token_info = access_token.get('/debug_token', :params => { :input_token => access_token.token, :access_token => app_access_token })
         # verify all needed scopes are allowed
-        missing_scopes = authorize_params.scope.split(',') - token_info.parsed.fetch("data", {}).fetch("scopes", [])
+        missing_scopes = authorize_params.scope.split(',').collect(&:strip) - token_info.parsed.fetch("data", {}).fetch("scopes", [])
         raise "missing scopes #{missing_scopes.join(', ')}" if missing_scopes.any?
       end
 


### PR DESCRIPTION
Allow access_token authorization. This time secured and verified by `/debug_token` Facebook API call (APP_ID and scopes are compared).
## TODO
- [ ] ensure this is the right way (please confirm)
  - [ ] @asmatameem #167
  - [x] @felipekk #167 
  - [x] @damianorenfer #160 
  - [ ] @fredkelly #90
- [ ] handle case when token is expired (it raises app_id doesn't match error)
- [ ] raise custom error when scopes are not met
- [ ] add tests
- [ ] refactor code
