### PR TITLE
Include query_string in the callback_url again

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -80,7 +80,7 @@ module OmniAuth
           ''
         else
           # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
-          options[:callback_url] || (full_host + script_name + callback_path)
+          options[:callback_url] || super
         end
       end
 
@@ -172,6 +172,11 @@ module OmniAuth
 
       def appsecret_proof
         @appsecret_proof ||= OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, client.secret, access_token.token)
+      end
+
+      def query_string
+        return '' if request.query_string.empty?
+        "?#{Rack::Utils.parse_nested_query(request.query_string).except('code', 'state').to_param}"
       end
     end
   end

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -175,8 +175,9 @@ module OmniAuth
       end
 
       def query_string
-        return '' if request.query_string.empty?
-        "?#{Rack::Utils.parse_nested_query(request.query_string).except('code', 'state').to_param}"
+        params = Rack::Utils.parse_nested_query(request.query_string).except('code', 'state')
+        return '' if params.empty?
+        "?#{params.to_param}"
       end
     end
   end

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -24,21 +24,21 @@ class ClientTest < StrategyTestCase
 end
 
 class CallbackUrlTest < StrategyTestCase
-  test "returns the default callback url (omitting querystring)" do
+  test "returns the default callback url" do
     url_base = 'http://auth.request.com'
     @request.stubs(:url).returns("#{url_base}/some/page")
     strategy.stubs(:script_name).returns('') # as not to depend on Rack env
     strategy.stubs(:query_string).returns('?foo=bar')
-    assert_equal "#{url_base}/auth/facebook/callback", strategy.callback_url
+    assert_equal "#{url_base}/auth/facebook/callback?foo=bar", strategy.callback_url
   end
 
-  test "returns path from callback_path option (omitting querystring)" do
+  test "returns path from callback_path option" do
     @options = { callback_path: "/auth/FB/done"}
     url_base = 'http://auth.request.com'
     @request.stubs(:url).returns("#{url_base}/page/path")
     strategy.stubs(:script_name).returns('') # as not to depend on Rack env
     strategy.stubs(:query_string).returns('?foo=bar')
-    assert_equal "#{url_base}/auth/FB/done", strategy.callback_url
+    assert_equal "#{url_base}/auth/FB/done?foo=bar", strategy.callback_url
   end
 
   test "returns url from callback_url option" do


### PR DESCRIPTION
#221 removes the query_string from the callback_url.

This was done to prevent the error "Error validating verification code. Please make sure your redirect_uri is identical to the one you used in the OAuth dialog request".

This error was caused by two additionally params ('code' and 'state') added by Facebook to the redirect url.

#221 works when you don't need query params in your redirect url, but fails when you do. This commit will fix this, by including the query_string again, but filtering out the ’code’ and ‘state’ params.