### PR TITLE
Non-versioned Facebook API now responds with json

### DIFF
--- a/lib/omniauth/facebook/version.rb
+++ b/lib/omniauth/facebook/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Facebook
-    VERSION = "1.5.1"
+    VERSION = "1.5.2"
   end
 end

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -16,7 +16,7 @@ module OmniAuth
       }
 
       option :token_params, {
-        :parse => :query
+        :parse => :json
       }
 
       option :access_token_options, {


### PR DESCRIPTION
The 1.5.x versions of this gem use the facebook graph api without specifying a version. This means that it's really hitting the oldest version of the API is still supported by facebook. Last week facebook dropped  support for what was then their oldest version. The one that took its place responds from the `/debug_token` endpoint with json, instead of with the query format.

This PR updates the 1-5 stable branch to use a json parser, thereby allowing legacy apps to make a patch version bump and continue operating normally.