### PR TITLE
Allow setting locale per request

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -22,7 +22,7 @@ module OmniAuth
         param_name: 'access_token'
       }
 
-      option :authorize_options, [:scope, :display, :auth_type]
+      option :authorize_options, [:scope, :display, :auth_type, :locale]
 
       uid { raw_info['id'] }
 
@@ -88,13 +88,13 @@ module OmniAuth
         options.access_token_options.inject({}) { |h,(k,v)| h[k.to_sym] = v; h }
       end
 
-      # You can pass +display+, +scope+, or +auth_type+ params to the auth request, if you need to set them dynamically.
+      # You can pass +display+, +scope+, +auth_type+ or +locale+ params to the auth request, if you need to set them dynamically.
       # You can also set these options in the OmniAuth config :authorize_params option.
       #
       # For example: /auth/facebook?display=popup
       def authorize_params
         super.tap do |params|
-          %w[display scope auth_type].each do |v|
+          %w[display scope auth_type locale].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
             end

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -66,6 +66,12 @@ class AuthorizeParamsTest < StrategyTestCase
     assert_equal 'reauthenticate', strategy.authorize_params[:auth_type]
   end
 
+  test 'includes locale parameter from request when present' do
+    @request.stubs(:params).returns({ 'locale' => 'en' })
+    assert strategy.authorize_params.is_a?(Hash)
+    assert_equal 'en', strategy.authorize_params[:locale]
+  end
+
   test 'overrides default scope with parameter passed from request' do
     @request.stubs(:params).returns({ 'scope' => 'email' })
     assert strategy.authorize_params.is_a?(Hash)


### PR DESCRIPTION
In a multi-lang app we need to set locale per request to get localized user name. However I haven't found a way to dynamically set locale in `info_options`, can you help me with this?
P.S. What's the point of having `authorize_options`? It's not used, #239 was rejected.