### PR TITLE
Add an option to not use the middleware when the request is a GET, since Facebook has no CSRF protection on their auth endpoints

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -24,6 +24,8 @@ module OmniAuth
 
       option :authorize_options, [:scope, :display, :auth_type]
 
+      option :disable_request_phase_get, false
+
       uid { raw_info['id'] }
 
       info do
@@ -110,6 +112,11 @@ module OmniAuth
         super.tap do |token|
           token.options.merge!(access_token_options)
         end
+      end
+
+      def request_phase
+        call_app! if request.request_method == "GET" && options.disable_request_phase_get
+        super
       end
 
       private


### PR DESCRIPTION
Context: https://sakurity.com/blog/2015/03/05/RECONNECT.html

Effectively, endpoints like the one exposed by this gem can be abused to perform an arbitrary Facebook login without the user's consent. This adds a non-breaking default-off option for gem users to stop GET requests to the endpoint (or at least forward them to their app).