### PR TITLE
Silence Ruby 2.5 and Minitest 6 deprecation warnings

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -76,7 +76,7 @@ module OmniAuth
       #      phase and it must match during the access_token phase:
       #      https://github.com/facebook/facebook-php-sdk/blob/master/src/base_facebook.php#L477
       def callback_url
-        if @authorization_code_from_signed_request_in_cookie
+        if defined?(@authorization_code_from_signed_request_in_cookie) && @authorization_code_from_signed_request_in_cookie
           ''
         else
           # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -11,6 +11,9 @@ module OmniAuth
 
       DEFAULT_SCOPE = 'email'
 
+      attr_accessor :authorization_code_from_signed_request_in_cookie
+      private :authorization_code_from_signed_request_in_cookie
+
       option :client_options, {
         site: 'https://graph.facebook.com/v2.10',
         authorize_url: "https://www.facebook.com/v2.10/dialog/oauth",
@@ -76,7 +79,7 @@ module OmniAuth
       #      phase and it must match during the access_token phase:
       #      https://github.com/facebook/facebook-php-sdk/blob/master/src/base_facebook.php#L477
       def callback_url
-        if defined?(@authorization_code_from_signed_request_in_cookie) && @authorization_code_from_signed_request_in_cookie
+        if authorization_code_from_signed_request_in_cookie
           ''
         else
           # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
@@ -131,7 +134,7 @@ module OmniAuth
           yield
         elsif code_from_signed_request = signed_request_from_cookie && signed_request_from_cookie['code']
           request.params['code'] = code_from_signed_request
-          @authorization_code_from_signed_request_in_cookie = true
+          self.authorization_code_from_signed_request_in_cookie = true
           # NOTE The code from the signed fbsr_XXX cookie is set by the FB JS SDK will confirm that the identity of the
           #      user contained in the signed request matches the user loading the app.
           original_provider_ignores_state = options.provider_ignores_state
@@ -140,7 +143,7 @@ module OmniAuth
             yield
           ensure
             request.params.delete('code')
-            @authorization_code_from_signed_request_in_cookie = false
+            self.authorization_code_from_signed_request_in_cookie = false
             options.provider_ignores_state = original_provider_ignores_state
           end
         else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -54,4 +54,4 @@ class StrategyTestCase < TestCase
   end
 end
 
-Dir[File.expand_path('../support/**/*', __FILE__)].each &method(:require)
+Dir[File.expand_path('../support/**/*', __FILE__)].each(&method(:require))

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,6 +45,7 @@ class StrategyTestCase < TestCase
 
   def strategy
     @strategy ||= begin
+      @options ||= nil
       args = [@client_id, @client_secret, @options].compact
       OmniAuth::Strategies::Facebook.new(nil, *args).tap do |strategy|
         strategy.stubs(:request).returns(@request)

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -452,7 +452,7 @@ module SignedRequestTests
     end
 
     test 'empty param' do
-      assert_equal nil, strategy.send(:signed_request_from_cookie)
+      assert_nil strategy.send(:signed_request_from_cookie)
     end
   end
 


### PR DESCRIPTION
Running the test suite in Ruby 2.5 yields a number of warnings:

```
Run options: --seed 11386

# Running:

../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
..../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
.../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
.../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/lib/omniauth/strategies/facebook.rb:79: warning: instance variable @authorization_code_from_signed_request_in_cookie not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
/home/niels/Projects/omniauth-facebook/lib/omniauth/strategies/facebook.rb:79: warning: instance variable @authorization_code_from_signed_request_in_cookie not initialized
./home/niels/Projects/omniauth-facebook/lib/omniauth/strategies/facebook.rb:79: warning: instance variable @authorization_code_from_signed_request_in_cookie not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
DEPRECATED: Use assert_nil if expecting nil from /home/niels/Projects/omniauth-facebook/test/strategy_test.rb:455. This will fail in Minitest 6.
....../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
......../home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
./home/niels/Projects/omniauth-facebook/test/helper.rb:48: warning: instance variable @options not initialized
.

Finished in 0.080105s, 911.2988 runs/s, 1435.6077 assertions/s.

73 runs, 115 assertions, 0 failures, 0 errors, 0 skips
```

This PR removes all of them.