### PR TITLE
Test that using a cookie authorization code sets callback_url to an e…

### DIFF
--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -439,6 +439,18 @@ module SignedRequestTests
       assert_equal @payload, strategy.send(:signed_request_from_cookie)
     end
 
+    test 'requests the access token with an empty redirect_uri' do
+      @access_token = stub_everything('OAuth2::AccessToken')
+      @access_token.stubs(:options).returns({})
+
+      strategy.stubs(:env).returns({})
+      strategy.stubs(:raw_info).returns({})
+      strategy.instance_variable_set("@app", Rack::Builder.new { run lambda { |*args| } }.to_app)
+
+      strategy.client.class.any_instance.expects(:get_token).with(has_entries(redirect_uri: ''), any_parameters).returns(@access_token)
+      strategy.callback_phase
+    end
+
     test 'throws an error if the algorithm is unknown' do
       setup('UNKNOWN-ALGO')
       assert_equal "unknown algorithm: UNKNOWN-ALGO", assert_raises(OmniAuth::Facebook::SignedRequest::UnknownSignatureAlgorithmError) { strategy.send(:signed_request_from_cookie) }.message


### PR DESCRIPTION
Start extending the test suite per https://github.com/mkdynamic/omniauth-facebook/pull/294#discussion_r178277636.

I don't like the stubbing/mocking in this one at all. Some of it is necessary only because we overwrite omniauth-provided helpers like https://github.com/omniauth/omniauth/blob/master/lib/omniauth/test/strategy_test_case.rb in https://github.com/mkdynamic/omniauth-facebook/blob/master/test/helper.rb#L33.

However, making the tests more usable overall would be a lot more work requiring prior design discussions.

TBD by the maintainers if it makes sense to continue extending the test suite as done in this PR.