### PR TITLE
Specify required Ruby version >= 2.0 to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Changes:
+
+  - Specify required Ruby version >= 2.0 to gemspec (#307, @koic)
+
 ## 5.0.0 (2018-03-29)
 
 Changes:

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary  = 'Facebook OAuth2 Strategy for OmniAuth'
   s.homepage = 'https://github.com/mkdynamic/omniauth-facebook'
   s.license  = 'MIT'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Follow up of #298.

This PR specifies required Ruby version >= 2.0 to gemspec.

This `required_ruby_version` attribute will Ruby version check on installation using `gem`.
And rubygems.org site shows required ruby version.
https://rubygems.org/gems/omniauth-facebook