### PR TITLE
Allow users to dynamically set callback url

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -80,7 +80,7 @@ module OmniAuth
           ''
         else
           # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
-          options[:callback_url] || (full_host + script_name + callback_path)
+          request.params['redirect_uri'] || options[:callback_url] || (full_host + script_name + callback_path)
         end
       end
 

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -41,6 +41,12 @@ class CallbackUrlTest < StrategyTestCase
     assert_equal "#{url_base}/auth/FB/done", strategy.callback_url
   end
 
+  test "returns url from redirect_uri params" do
+    redirect_uri = 'http://redirect.com'
+    @request.stubs(:params).returns({ 'redirect_uri' => redirect_uri })
+    assert_equal redirect_uri, strategy.callback_url
+  end
+
   test "returns url from callback_url option" do
     url = 'https://auth.myapp.com/auth/fb/callback'
     @options = { callback_url: url }


### PR DESCRIPTION
@mkdynamic 
I create this pull request to let users dynamically set callback url by putting `redirect_uri=#{some_url}` in request.
Currently users can only set callback_url using options in `initializers/devise.rb` or `initializers/ominauth.rb`.
But with this method, there is only one callback path. So if developers want to have customized callback URLs for each kind of request, they may need to use constraints.
If we can dynamically set callback path, it is easier to have multiple omniauth request/callback pairs for different purpose. For example: 
1. For sign up: request = `/users/auth/facebook?redirect_uri=signup_path`
2. For deactivate account: request = `/users/auth/facebook?redirect_uri=deactivate_account_path`

FYI: I learn this approach from `google_oauth2` : https://github.com/omniauth/omniauth/issues/593#issuecomment-29777604
(I had tried it, and it worked on my own app).