### PR TITLE
Remove references to info fields that Facebook no longer returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Here's an example *Auth Hash* available in `request.env['omniauth.auth']`:
     first_name: 'Joe',
     last_name: 'Bloggs',
     image: 'http://graph.facebook.com/1234567/picture?type=square',
-    verified: true
   },
   credentials: {
     token: 'ABCDEF...', # OAuth 2.0 access_token, which you may wish to store
@@ -106,10 +105,6 @@ Here's an example *Auth Hash* available in `request.env['omniauth.auth']`:
       location: { id: '123456789', name: 'Palo Alto, California' },
       gender: 'male',
       email: 'joe@bloggs.com',
-      timezone: -8,
-      locale: 'en_US',
-      verified: true,
-      updated_time: '2011-11-11T06:21:03+0000',
       # ...
     }
   }

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -40,7 +40,6 @@ module OmniAuth
             'Website' => raw_info['website']
           },
           'location' => (raw_info['location'] || {})['name'],
-          'verified' => raw_info['verified']
         })
       end
 

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -198,16 +198,6 @@ class InfoTestOptionalDataPresent < StrategyTestCase
     assert_equal 'http://www.facebook.com/fredsmith', strategy.info['urls']['Facebook']
     assert_equal 'https://my-wonderful-site.com', strategy.info['urls']['Website']
   end
-
-  test 'returns the positive verified status' do
-    @raw_info['verified'] = true
-    assert strategy.info['verified']
-  end
-
-  test 'returns the negative verified status' do
-    @raw_info['verified'] = false
-    refute strategy.info['verified']
-  end
 end
 
 class InfoTestOptionalDataNotPresent < StrategyTestCase
@@ -243,10 +233,6 @@ class InfoTestOptionalDataNotPresent < StrategyTestCase
 
   test 'has no urls' do
     refute_has_key 'urls', strategy.info
-  end
-
-  test 'has no verified key' do
-    refute_has_key 'verified', strategy.info
   end
 end
 


### PR DESCRIPTION
The following user fields are no longer returned by the Facebook API:

- `timezone`
- `locale`
- `cover`
- `is_verified`
- `updated_time`
- `verified`
- `currency`
- `devices`
- `third_party_id`

This change took effect for new apps on May 1, 2018, but just started affecting existing apps on January 8, 2019. See the [announcement](https://developers.facebook.com/blog/post/2018/05/01/facebook-login-updates-further-protect-privacy/) and the [changelog](https://developers.facebook.com/docs/facebook-login/changelog/#2018-07-02).

At least based on what I've found (but I'm not 100% sure), there is no way to get these fields back anymore, so I thought it might make sense to remove them from the docs to avoid confusion.