### PR TITLE
Fix `uninitialized constant MultiJson` in example

### DIFF
--- a/example/app.rb
+++ b/example/app.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require "sinatra/reloader"
+require 'multi_json'
 require 'yaml'
 
 # configure sinatra


### PR DESCRIPTION
I got this error when testing `client-side` flow.
`MultiJson` is used but not required.
https://github.com/mkdynamic/omniauth-facebook/blob/e9fa92e83649866e2749d9defc711f86ea6152bf/example/app.rb#L85