### PR TITLE
Sending signedRequest over parameters instead of relying on cookie.

### DIFF
--- a/lib/omniauth/facebook/version.rb
+++ b/lib/omniauth/facebook/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Facebook
-    VERSION = '5.0.0'
+    VERSION = '5.0.1'
   end
 end

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -119,7 +119,7 @@ module OmniAuth
       end
 
       def raw_signed_request_from_cookie
-        request.cookies["fbsr_#{client.id}"]
+        request.cookies["fbsr_#{client.id}"] || request.params['signed_request']
       end
 
       # Picks the authorization code in order, from:


### PR DESCRIPTION
By using React and Facebook SDK inside it, to authenticate in XHR, things have been not nice to set a cookie. 

To overcome this issue, I've patched the signed request to check it both in cookie and params.

That way, the signed_request can be sent as a param to perform the same way as it would if one had the cookie set.