### PR TITLE
CI: Use cache, test only on supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
-before_install:
-  - gem update bundler
-  - bundle --version
-  - gem update --system
-  - gem --version
+language: ruby
+cache: bundler
 rvm:
+  - 2.7
   - 2.6
   - 2.5
-  - 2.4
-  - 2.3


### PR DESCRIPTION
This PR adds caching for Bundler, and reduces the test matrix to only include in-support Ruby versions. See https://www.ruby-lang.org/en/downloads/branches/ for more on what's in support.