### PR TITLE
#343. add access token params in the profile picture url

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -161,13 +161,15 @@ module OmniAuth
         uri_class = options[:secure_image_url] ? URI::HTTPS : URI::HTTP
         site_uri = URI.parse(client.site)
         url = uri_class.build({host: site_uri.host, path: "#{site_uri.path}/#{uid}/picture"})
+        query = { access_token: access_token.token }
 
-        query = if options[:image_size].is_a?(String) || options[:image_size].is_a?(Symbol)
-          { type: options[:image_size] }
+        if options[:image_size].is_a?(String) || options[:image_size].is_a?(Symbol)
+          query[:type] = options[:image_size]
         elsif options[:image_size].is_a?(Hash)
-          options[:image_size]
+          query.merge!(options[:image_size])
         end
-        url.query = Rack::Utils.build_query(query) if query
+
+        url.query = Rack::Utils.build_query(query)
 
         url.to_s
       end

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -95,41 +95,52 @@ class UidTest < StrategyTestCase
 end
 
 class InfoTest < StrategyTestCase
+  def setup
+    super
+    @access_token = stub('OAuth2::AccessToken')
+    @access_token.stubs(:token).returns('test_access_token')
+  end
+
   test 'returns the secure facebook avatar url when `secure_image_url` option is specified' do
     @options = { secure_image_url: true }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'https://graph.facebook.com/v4.0/321/picture', strategy.info['image']
+    strategy.stubs(:access_token).returns(@access_token)
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
   end
 
   test 'returns the image_url based of the client site' do
     @options = { secure_image_url: true, client_options: {site: "https://blah.facebook.com/v2.2"}}
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'https://blah.facebook.com/v2.2/321/picture', strategy.info['image']
+    strategy.stubs(:access_token).returns(@access_token)
+    assert_equal "https://blah.facebook.com/v2.2/321/picture?access_token=test_access_token", strategy.info['image']
   end
 
   test 'returns the image with size specified in the `image_size` option' do
     @options = { image_size: 'normal' }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture?type=normal', strategy.info['image']
+    strategy.stubs(:access_token).returns(@access_token)
+    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
   end
 
   test 'returns the image with size specified as a symbol in the `image_size` option' do
     @options = { image_size: :normal }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture?type=normal', strategy.info['image']
+    strategy.stubs(:access_token).returns(@access_token)
+    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
   end
 
   test 'returns the image with width and height specified in the `image_size` option' do
     @options = { image_size: { width: 123, height: 987 } }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
+    strategy.stubs(:access_token).returns(@access_token)
     assert_match 'width=123', strategy.info['image']
     assert_match 'height=987', strategy.info['image']
-    assert_match 'http://graph.facebook.com/v4.0/321/picture?', strategy.info['image']
+    assert_match 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
   end
 end
 
@@ -138,6 +149,10 @@ class InfoTestOptionalDataPresent < StrategyTestCase
     super
     @raw_info ||= { 'name' => 'Fred Smith' }
     strategy.stubs(:raw_info).returns(@raw_info)
+
+    access_token = stub('OAuth2::AccessToken')
+    access_token.stubs(:token).returns('test_access_token')
+    strategy.stubs(:access_token).returns(access_token)
   end
 
   test 'returns the name' do
@@ -176,7 +191,7 @@ class InfoTestOptionalDataPresent < StrategyTestCase
 
   test 'returns the facebook avatar url' do
     @raw_info['id'] = '321'
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture', strategy.info['image']
+    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
   end
 
   test 'returns the Facebook link as the Facebook url' do
@@ -215,6 +230,10 @@ class InfoTestOptionalDataNotPresent < StrategyTestCase
     super
     @raw_info ||= { 'name' => 'Fred Smith' }
     strategy.stubs(:raw_info).returns(@raw_info)
+
+    access_token = stub('OAuth2::AccessToken')
+    access_token.stubs(:token).returns('test_access_token')
+    strategy.stubs(:access_token).returns(access_token)
   end
 
   test 'has no email key' do


### PR DESCRIPTION
According to new facebook API change, it requires access token to fetch user profile picture: https://developers.facebook.com/docs/graph-api/reference/user/picture/

This pull request adds access token param in the image url, which resolves the issue I posted #343 