### PR TITLE
Change secure_image_url default from false to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Option name | Default | Explanation
 `info_fields` | `name,email` | Specify exactly which fields should be returned when getting the user's info. Value should be a comma-separated string as per https://developers.facebook.com/docs/graph-api/reference/user/ (only `/me` endpoint).
 `locale` |  | Specify locale which should be used when getting the user's info. Value should be locale string as per https://developers.facebook.com/docs/reference/api/locale/.
 `auth_type` | | Optionally specifies the requested authentication features as a comma-separated list, as per https://developers.facebook.com/docs/facebook-login/reauthentication/. Valid values are `https` (checks for the presence of the secure cookie and asks for re-authentication if it is not present), and `reauthenticate` (asks the user to re-authenticate unconditionally). Use 'rerequest' when you want to request premissions. Default is `nil`.
-`secure_image_url` | `false` | Set to `true` to use https for the avatar image url returned in the auth hash.
+`secure_image_url` | `true` | Set to `true` to use https for the avatar image url returned in the auth hash. SSL is mandatory as per https://developers.facebook.com/docs/facebook-login/security#surfacearea.
 `callback_url` / `callback_path` | | Specify a custom callback URL used during the server-side flow. Note this must be allowed by your app configuration on Facebook (see 'Valid OAuth redirect URIs' under the 'Advanced' settings section in the configuration for your Facebook app for more details).
 
 For example, to request `email`, `user_birthday` and `read_stream` permissions and display the authentication page in a popup window:

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -26,6 +26,8 @@ module OmniAuth
 
       option :authorize_options, [:scope, :display, :auth_type]
 
+      option :secure_image_url, true
+
       uid { raw_info['id'] }
 
       info do

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -101,8 +101,23 @@ class InfoTest < StrategyTestCase
     @access_token.stubs(:token).returns('test_access_token')
   end
 
-  test 'returns the secure facebook avatar url when `secure_image_url` option is specified' do
+  test 'returns the secure facebook avatar url when `secure_image_url` option is set to true' do
     @options = { secure_image_url: true }
+    raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
+    strategy.stubs(:raw_info).returns(raw_info)
+    strategy.stubs(:access_token).returns(@access_token)
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+  end
+
+  test 'returns the non-ssl facebook avatar url when `secure_image_url` option is set to false' do
+    @options = { secure_image_url: false }
+    raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
+    strategy.stubs(:raw_info).returns(raw_info)
+    strategy.stubs(:access_token).returns(@access_token)
+    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+  end
+
+  test 'returns the secure facebook avatar url when `secure_image_url` option is omitted' do
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
@@ -122,7 +137,7 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
   end
 
   test 'returns the image with size specified as a symbol in the `image_size` option' do
@@ -130,7 +145,7 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
   end
 
   test 'returns the image with width and height specified in the `image_size` option' do
@@ -140,7 +155,7 @@ class InfoTest < StrategyTestCase
     strategy.stubs(:access_token).returns(@access_token)
     assert_match 'width=123', strategy.info['image']
     assert_match 'height=987', strategy.info['image']
-    assert_match 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    assert_match 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
   end
 end
 
@@ -191,7 +206,7 @@ class InfoTestOptionalDataPresent < StrategyTestCase
 
   test 'returns the facebook avatar url' do
     @raw_info['id'] = '321'
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
   end
 
   test 'returns the Facebook link as the Facebook url' do


### PR DESCRIPTION
## Description
Default `secure_image_url` to `true`, see https://github.com/simi/omniauth-facebook/issues/345 for details.

closes https://github.com/simi/omniauth-facebook/issues/345

## Notes
As mentioned here https://github.com/simi/omniauth-facebook/issues/343#issuecomment-720614083 you can just turn on the `secure_image_url` in your settings for now. This PR just aims to change the default value, since it is mandatory. Eventually, in the next major version release, we can drop this option entirely, since there is no point in turning SSL off, if the Facebook API does not support it anymore anyway.