### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,7 @@
 name: Ruby
-on:
-  push:
-    branches:
-      - $default-branch
-  pull_request:
-    branches:
-      - $default-branch
+
+on: [push, pull_request]
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,31 @@
 name: Ruby
-  on:
-    push:
-      branches:
-        - master
-    pull_request:
-      branches:
-        - master
-  jobs:
-    test:
-      runs-on: ubuntu-18.04
-      strategy:
-        fail-fast: false
-        matrix:
-          os:
-            - ubuntu
-          ruby:
-            - "2.5"
-            - "2.6"
-            - "2.7"
-      steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Install dependencies
-        run: bundle install
-      - name: Run tests
-        run: bundle exec rake
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        ruby:
+          - "2.5"
+          - "2.6"
+          - "2.7"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - $default-branch
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Ruby
+  on:
+    push:
+      branches:
+        - master
+    pull_request:
+      branches:
+        - master
+  jobs:
+    test:
+      runs-on: ubuntu-18.04
+      strategy:
+        fail-fast: false
+        matrix:
+          os:
+            - ubuntu
+          ruby:
+            - "2.5"
+            - "2.6"
+            - "2.7"
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: Ruby
 on:
   push:
     branches:
-      - master
+      - $default-branch
   pull_request:
     branches:
-      - master
+      - $default-branch
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-cache: bundler
-rvm:
-  - 2.7
-  - 2.6
-  - 2.5


### PR DESCRIPTION
This PR tries to solve the problem that Travis will no longer offer free CI minutes for open source projects. By **getting off that service**.

- Drop Travis configuration
- Add a GitHub Actions configuration

Fixes #349 