### PR TITLE
Release 8.0.1 - add dependency constraint for omniauth 1.x series.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.0.1 (2021-03-xx)
+
+Changes:
+  - add dependency contrain for omniauth 1.x series. (#357)
+
 ## 8.0.0 (2020-10-20)
 
 Changes:

--- a/lib/omniauth/facebook/version.rb
+++ b/lib/omniauth/facebook/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Facebook
-    VERSION = '8.0.0'
+    VERSION = '8.0.1'
   end
 end

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'omniauth', '~> 1.0'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2', '< 1.7.1'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth', '~> 1.0'
+  s.add_runtime_dependency 'omniauth', '~> 1.2'
   s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2', '< 1.7.1'
 
   s.add_development_dependency 'minitest'

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'omniauth', '~> 1.2'
-  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2', '< 1.7.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
Hi,@simi

Could you check this about #357.

references

- dependency for omniauth-oauth v1.2
  - https://rubygems.org/gems/omniauth-oauth2/versions/1.2.0
- referred to other strategy PR
  - https://github.com/omniauth/omniauth-github/pull/95
