### PR TITLE
Send appsecret_proof in image_url requests

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -163,7 +163,7 @@ module OmniAuth
         uri_class = options[:secure_image_url] ? URI::HTTPS : URI::HTTP
         site_uri = URI.parse(client.site)
         url = uri_class.build({host: site_uri.host, path: "#{site_uri.path}/#{uid}/picture"})
-        query = { access_token: access_token.token }
+        query = { access_token: access_token.token, appsecret_proof: appsecret_proof }
 
         if options[:image_size].is_a?(String) || options[:image_size].is_a?(Symbol)
           query[:type] = options[:image_size]

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -98,6 +98,7 @@ class InfoTest < StrategyTestCase
   def setup
     super
     @access_token = stub('OAuth2::AccessToken')
+    @appsecret_proof = 'test_appsecret_proof'
     @access_token.stubs(:token).returns('test_access_token')
   end
 
@@ -106,7 +107,8 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof', strategy.info['image']
   end
 
   test 'returns the non-ssl facebook avatar url when `secure_image_url` option is set to false' do
@@ -114,14 +116,16 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    assert_equal 'http://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof', strategy.info['image']
   end
 
   test 'returns the secure facebook avatar url when `secure_image_url` option is omitted' do
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof', strategy.info['image']
   end
 
   test 'returns the image_url based of the client site' do
@@ -129,7 +133,8 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "https://blah.facebook.com/v2.2/321/picture?access_token=test_access_token", strategy.info['image']
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    assert_equal "https://blah.facebook.com/v2.2/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof", strategy.info['image']
   end
 
   test 'returns the image with size specified in the `image_size` option' do
@@ -137,7 +142,8 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof&type=normal', strategy.info['image']
   end
 
   test 'returns the image with size specified as a symbol in the `image_size` option' do
@@ -145,7 +151,8 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
-    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&type=normal', strategy.info['image']
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof&type=normal', strategy.info['image']
   end
 
   test 'returns the image with width and height specified in the `image_size` option' do
@@ -153,9 +160,10 @@ class InfoTest < StrategyTestCase
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
     strategy.stubs(:access_token).returns(@access_token)
+    strategy.stubs(:appsecret_proof).returns(@appsecret_proof)
     assert_match 'width=123', strategy.info['image']
     assert_match 'height=987', strategy.info['image']
-    assert_match 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    assert_match 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof', strategy.info['image']
   end
 end
 
@@ -168,6 +176,7 @@ class InfoTestOptionalDataPresent < StrategyTestCase
     access_token = stub('OAuth2::AccessToken')
     access_token.stubs(:token).returns('test_access_token')
     strategy.stubs(:access_token).returns(access_token)
+    strategy.stubs(:appsecret_proof).returns('test_appsecret_proof')
   end
 
   test 'returns the name' do
@@ -206,7 +215,7 @@ class InfoTestOptionalDataPresent < StrategyTestCase
 
   test 'returns the facebook avatar url' do
     @raw_info['id'] = '321'
-    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token', strategy.info['image']
+    assert_equal 'https://graph.facebook.com/v4.0/321/picture?access_token=test_access_token&appsecret_proof=test_appsecret_proof', strategy.info['image']
   end
 
   test 'returns the Facebook link as the Facebook url' do


### PR DESCRIPTION
Hi, this is my first time contributing to this repo so please let me know if I've missed anything.

This PR implements the suggestion in https://github.com/simi/omniauth-facebook/issues/347 to prevent errors like "API calls from the server require an appsecret_proof
argument"

Our app has the same problem, since we have configured it to require all requests to include `appsecret_proof` as described in https://github.com/simi/omniauth-facebook/issues/347#issuecomment-714771108 (this setting is documented in https://developers.facebook.com/docs/graph-api/securing-requests).

We encountered this same error when upgrading to 8.0.0 (due to access token being added to this request) and adding this parameter fixes the problem.