### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.