### PR TITLE
Remove duplicated script_name in callback_url

### DIFF
--- a/lib/omniauth/facebook/signed_request.rb
+++ b/lib/omniauth/facebook/signed_request.rb
@@ -28,7 +28,7 @@ module OmniAuth
         return if signature.nil?
 
         decoded_hex_signature = base64_decode_url(signature)
-        decoded_payload = MultiJson.decode(base64_decode_url(encoded_payload))
+        decoded_payload = JSON.parse(base64_decode_url(encoded_payload))
 
         unless decoded_payload['algorithm'] == SUPPORTED_ALGORITHM
           raise UnknownSignatureAlgorithmError, "unknown algorithm: #{decoded_payload['algorithm']}"

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -85,7 +85,7 @@ module OmniAuth
           ''
         else
           # Fixes regression in omniauth-oauth2 v1.4.0 by https://github.com/intridea/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7
-          options[:callback_url] || (full_host + script_name + callback_path)
+          options[:callback_url] || (full_host + callback_path)
         end
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
 require 'minitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'omniauth/strategies/facebook'
 
 OmniAuth.config.test_mode = true

--- a/test/signed_request_test.rb
+++ b/test/signed_request_test.rb
@@ -5,7 +5,7 @@ class SignedRequestTest < Minitest::Test
   def setup
     @value = fixture('signed_request.txt').strip
     @secret = "897z956a2z7zzzzz5783z458zz3z7556"
-    @expected_payload = MultiJson.decode(fixture('payload.json'))
+    @expected_payload = JSON.parse(fixture('payload.json'))
   end
 
   def test_signed_request_payload

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -26,10 +26,11 @@ end
 class CallbackUrlTest < StrategyTestCase
   test "returns the default callback url (omitting querystring)" do
     url_base = 'http://auth.request.com'
+    script_name = '/script_name'
     @request.stubs(:url).returns("#{url_base}/some/page")
-    strategy.stubs(:script_name).returns('') # as not to depend on Rack env
+    strategy.stubs(:script_name).returns(script_name) # as not to depend on Rack env
     strategy.stubs(:query_string).returns('?foo=bar')
-    assert_equal "#{url_base}/auth/facebook/callback", strategy.callback_url
+    assert_equal "#{url_base}#{script_name}/auth/facebook/callback", strategy.callback_url
   end
 
   test "returns path from callback_path option (omitting querystring)" do
@@ -427,7 +428,7 @@ end
 
 module SignedRequestHelpers
   def signed_request(payload, secret)
-    encoded_payload = base64_encode_url(MultiJson.encode(payload))
+    encoded_payload = base64_encode_url(JSON.dump(payload))
     encoded_signature = base64_encode_url(signature(encoded_payload, secret))
     [encoded_signature, encoded_payload].join('.')
   end


### PR DESCRIPTION
First, thanks for providing and maintaining this gem, it helped us integrate with facebook and providing some products on top of it for quite some time. Lately, we found an issue with our setup. We have a rails application running behind a reverse proxy and as we use Sidekiq and want to keep using the Sidekiq Web UIs we set `SCRIPT_NAME` as env var.

This led to some weird behaviour with omniauth-facebook/omniauth though, the `redirect_uri` started to contain the `SCRIPT_NAME` part twice. When digging through the code we can see `omniauth-facebook` uses `script_name` to construct the `callback_url` in https://github.com/simi/omniauth-facebook/blob/master/lib/omniauth/strategies/facebook.rb#L88.

Taking a look at omniauth we can then see `callback_path` is as well constructed with `script_name` in it (https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L450). The fix to rely on the default values here while still being able to set `SCRIPT_NAME` would be to get rid of the usage in `omniauth-facebook`.