### PR TITLE
Update gemspec and version number

### DIFF
--- a/lib/omniauth/facebook/version.rb
+++ b/lib/omniauth/facebook/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Facebook
-    VERSION = '9.0.0'
+    VERSION = '9.0.1'
   end
 end

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.2'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2', '< 3'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
Required to update omniauth to v2, which is in turn mandatory for migrating to Ruby 3