### PR TITLE
Add Ruby 3.2 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
* Ruby 3.2 has been out for a while and it is helpful to know if this gem is compatible
* https://www.ruby-lang.org/en/downloads/releases/