### PR TITLE
Tell users to allow GET requests to omniauth-provided paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ use OmniAuth::Builder do
       authorize_url: "https://www.facebook.com/v7.0/dialog/oauth"
     }
 end
+OmniAuth.config.allowed_request_methods = %i[get]
 ```
 
 ### Per-Request Options


### PR DESCRIPTION
I spent a while trying to get this to work and discovered this was the missing piece. 