### PR TITLE
Add config_id to Per-Request options and Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ You can configure several options, which you pass in to the `provider` method vi
 Option name | Default | Explanation
 --- | --- | ---
 `scope` | `email` | A comma-separated list of permissions you want to request from the user. See the Facebook docs for a full list of available permissions: https://developers.facebook.com/docs/reference/login/
-`display` | `page` | The display context to show the authentication page. Options are: `page`, `popup` and `touch`. Read the Facebook docs for more details: https://developers.facebook.com/docs/reference/dialogs/oauth/
+`display` | `page` | The display context to show the authentication page. Options are: `page`, `popup` and 
+`config_id` |  | The configuration ID to use for a System User access token with Facebook Login for Business. Read the Facebook docs for more details: https://developers.facebook.com/docs/facebook-login/facebook-login-for-business#invoke-a--login-dialog
+`touch`. Read the Facebook docs for more details: https://developers.facebook.com/docs/reference/dialogs/oauth/
 `image_size` | `square` | Set the size for the returned image url in the auth hash. Valid options include `square` (50x50), `small` (50 pixels wide, variable height), `normal` (100 pixels wide, variable height), or `large` (about 200 pixels wide, variable height). Additionally, you can request a picture of a specific size by setting this option to a hash with `:width` and `:height` as keys. This will return an available profile picture closest to the requested size and requested aspect ratio. If only `:width` or `:height` is specified, we will return a picture whose width or height is closest to the requested size, respectively.
 `info_fields` | `name,email` | Specify exactly which fields should be returned when getting the user's info. Value should be a comma-separated string as per https://developers.facebook.com/docs/graph-api/reference/user/ (only `/me` endpoint).
 `locale` |  | Specify locale which should be used when getting the user's info. Value should be locale string as per https://developers.facebook.com/docs/reference/api/locale/.
@@ -72,7 +74,7 @@ end
 
 ### Per-Request Options
 
-If you want to set the `display` format, `auth_type`, or `scope` on a per-request basis, you can just pass it to the OmniAuth request phase URL, for example: `/auth/facebook?display=popup` or `/auth/facebook?scope=email`.
+If you want to set the `display` format, `auth_type`, `scope` or `config_id` on a per-request basis, you can just pass it to the OmniAuth request phase URL, for example: `/auth/facebook?display=popup`, `/auth/facebook?scope=email` or `/auth/facebook?config_id=001`.
 
 ## Auth Hash
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -10,7 +10,7 @@ module OmniAuth
       class NoAuthorizationCodeError < StandardError; end
 
       DEFAULT_SCOPE = 'email'
-      DEFAULT_FACEBOOK_API_VERSION = 'v19.0'.freeze
+      DEFAULT_FACEBOOK_API_VERSION = 'v5.0'.freeze
 
       option :client_options, {
         site: "https://graph.facebook.com/#{DEFAULT_FACEBOOK_API_VERSION}",

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -93,7 +93,7 @@ module OmniAuth
         options.access_token_options.inject({}) { |h,(k,v)| h[k.to_sym] = v; h }
       end
 
-      # You can pass +display+, +scope+, or +auth_type+ params to the auth request, if you need to set them dynamically.
+      # You can pass +display+, +scope+, +auth_type+ or +config_id+ params to the auth request, if you need to set them dynamically.
       # You can also set these options in the OmniAuth config :authorize_params option.
       #
       # For example: /auth/facebook?display=popup

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -10,7 +10,7 @@ module OmniAuth
       class NoAuthorizationCodeError < StandardError; end
 
       DEFAULT_SCOPE = 'email'
-      DEFAULT_FACEBOOK_API_VERSION = 'v5.0'.freeze
+      DEFAULT_FACEBOOK_API_VERSION = 'v19.0'.freeze
 
       option :client_options, {
         site: "https://graph.facebook.com/#{DEFAULT_FACEBOOK_API_VERSION}",
@@ -25,7 +25,7 @@ module OmniAuth
 
       option :authorization_code_from_signed_request_in_cookie, nil
 
-      option :authorize_options, [:scope, :display, :auth_type]
+      option :authorize_options, [:scope, :display, :auth_type, :config_id]
 
       option :secure_image_url, true
 
@@ -99,7 +99,7 @@ module OmniAuth
       # For example: /auth/facebook?display=popup
       def authorize_params
         super.tap do |params|
-          %w[display scope auth_type].each do |v|
+          %w[display scope auth_type config_id].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
             end

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -61,6 +61,12 @@ class AuthorizeParamsTest < StrategyTestCase
     assert_equal 'touch', strategy.authorize_params[:display]
   end
 
+  test 'includes config_id parameter from request when present' do
+    @request.stubs(:params).returns({ 'config_id' => '000111222' })
+    assert strategy.authorize_params.is_a?(Hash)
+    assert_equal '000111222', strategy.authorize_params[:config_id]
+  end
+
   test 'includes auth_type parameter from request when present' do
     @request.stubs(:params).returns({ 'auth_type' => 'reauthenticate' })
     assert strategy.authorize_params.is_a?(Hash)


### PR DESCRIPTION
This pull request enhances the OmniAuth-Facebook gem by adding support for config_id in both authorize_options and authorize_params. 

We encountered an issue where the OAuth login page was blank due to the absence of config_id, which is a configuration parameter required for Facebook's Business Login product. This update resolves the issue and improves the flexibility and configurability of the gem, enabling developers to specify a `config_id` during the authorization process.

Notably, `config_id` can be provided via URL, allowing developers to specify config_id per request and also globally via configuration if there's only configuration in the system.

Read more at: [https://developers.facebook.com/docs/facebook-login/facebook-login-for-business#opt-in-to-facebook-login-for-business](https://developers.facebook.com/docs/facebook-login/facebook-login-for-business#opt-in-to-facebook-login-for-business)



