### PR TITLE
Remove access token for profile picture URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Here's an example *Auth Hash* available in `request.env['omniauth.auth']`:
     name: 'Joe Bloggs',
     first_name: 'Joe',
     last_name: 'Bloggs',
-    image: 'http://graph.facebook.com/1234567/picture?type=square&access_token=...',
+    image: 'http://graph.facebook.com/1234567/picture?type=square',
     verified: true
   },
   credentials: {

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -164,15 +164,13 @@ module OmniAuth
         uri_class = options[:secure_image_url] ? URI::HTTPS : URI::HTTP
         site_uri = URI.parse(client.site)
         url = uri_class.build({host: site_uri.host, path: "#{site_uri.path}/#{uid}/picture"})
-        query = { access_token: access_token.token }
 
-        if options[:image_size].is_a?(String) || options[:image_size].is_a?(Symbol)
-          query[:type] = options[:image_size]
+        query = if options[:image_size].is_a?(String) || options[:image_size].is_a?(Symbol)
+          { type: options[:image_size] }
         elsif options[:image_size].is_a?(Hash)
-          query.merge!(options[:image_size])
+          options[:image_size]
         end
-
-        url.query = Rack::Utils.build_query(query)
+        url.query = Rack::Utils.build_query(query) if query
 
         url.to_s
       end

--- a/test/strategy_test.rb
+++ b/test/strategy_test.rb
@@ -96,67 +96,54 @@ class UidTest < StrategyTestCase
 end
 
 class InfoTest < StrategyTestCase
-  def setup
-    super
-    @access_token = stub('OAuth2::AccessToken')
-    @access_token.stubs(:token).returns('test_access_token')
-  end
-
   test 'returns the secure facebook avatar url when `secure_image_url` option is set to true' do
     @options = { secure_image_url: true }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token", strategy.info['image']
+    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture", strategy.info['image']
   end
 
   test 'returns the non-ssl facebook avatar url when `secure_image_url` option is set to false' do
     @options = { secure_image_url: false }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "http://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token", strategy.info['image']
+    assert_equal "http://graph.facebook.com/#{@facebook_api_version}/321/picture", strategy.info['image']
   end
 
   test 'returns the secure facebook avatar url when `secure_image_url` option is omitted' do
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token", strategy.info['image']
+    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture", strategy.info['image']
   end
 
   test 'returns the image_url based of the client site' do
     @options = { secure_image_url: true, client_options: {site: "https://blah.facebook.com/v2.2"}}
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "https://blah.facebook.com/v2.2/321/picture?access_token=test_access_token", strategy.info['image']
+    assert_equal "https://blah.facebook.com/v2.2/321/picture", strategy.info['image']
   end
 
   test 'returns the image with size specified in the `image_size` option' do
     @options = { image_size: 'normal' }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token&type=normal", strategy.info['image']
+    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?type=normal", strategy.info['image']
   end
 
   test 'returns the image with size specified as a symbol in the `image_size` option' do
     @options = { image_size: :normal }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
-    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token&type=normal", strategy.info['image']
+    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?type=normal", strategy.info['image']
   end
 
   test 'returns the image with width and height specified in the `image_size` option' do
     @options = { image_size: { width: 123, height: 987 } }
     raw_info = { 'name' => 'Fred Smith', 'id' => '321' }
     strategy.stubs(:raw_info).returns(raw_info)
-    strategy.stubs(:access_token).returns(@access_token)
     assert_match 'width=123', strategy.info['image']
     assert_match 'height=987', strategy.info['image']
-    assert_match "https://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token", strategy.info['image']
+    assert_match "https://graph.facebook.com/#{@facebook_api_version}/321/picture", strategy.info['image']
   end
 end
 
@@ -165,10 +152,6 @@ class InfoTestOptionalDataPresent < StrategyTestCase
     super
     @raw_info ||= { 'name' => 'Fred Smith' }
     strategy.stubs(:raw_info).returns(@raw_info)
-
-    access_token = stub('OAuth2::AccessToken')
-    access_token.stubs(:token).returns('test_access_token')
-    strategy.stubs(:access_token).returns(access_token)
   end
 
   test 'returns the name' do
@@ -207,7 +190,7 @@ class InfoTestOptionalDataPresent < StrategyTestCase
 
   test 'returns the facebook avatar url' do
     @raw_info['id'] = '321'
-    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture?access_token=test_access_token", strategy.info['image']
+    assert_equal "https://graph.facebook.com/#{@facebook_api_version}/321/picture", strategy.info['image']
   end
 
   test 'returns the Facebook link as the Facebook url' do
@@ -246,10 +229,6 @@ class InfoTestOptionalDataNotPresent < StrategyTestCase
     super
     @raw_info ||= { 'name' => 'Fred Smith' }
     strategy.stubs(:raw_info).returns(@raw_info)
-
-    access_token = stub('OAuth2::AccessToken')
-    access_token.stubs(:token).returns('test_access_token')
-    strategy.stubs(:access_token).returns(access_token)
   end
 
   test 'has no email key' do


### PR DESCRIPTION
Access token for profile picture URL is not necessary and could lead to problems with expired access tokens when URL stored in DB

This pull request removes the access token param in the image URL, which resolves the issue I posted: https://github.com/simi/omniauth-facebook/issues/387