### PR TITLE
Update default API version to v19.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,13 @@ jobs:
         os:
           - ubuntu
         ruby:
-          - "2.5"
-          - "2.6"
-          - "2.7"
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
+          - head
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu
         ruby:
           - "3.0"
           - "3.1"

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ end
 
 ### API Version
 
-OmniAuth Facebook uses versioned API endpoints by default (current v5.0). You can configure a different version via `client_options` hash passed to `provider`, specifically you should change the version in the `site` and `authorize_url` parameters. For example, to change to v7.0 (assuming that exists):
+OmniAuth Facebook uses versioned API endpoints by default (current v19.0). You can configure a different version via `client_options` hash passed to `provider`, specifically you should change the version in the `site` and `authorize_url` parameters. For example, to change to v20.0 (assuming that exists):
 
 ```ruby
 use OmniAuth::Builder do
   provider :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET'],
     client_options: {
-      site: 'https://graph.facebook.com/v7.0',
-      authorize_url: "https://www.facebook.com/v7.0/dialog/oauth"
+      site: 'https://graph.facebook.com/v20.0',
+      authorize_url: "https://www.facebook.com/v20.0/dialog/oauth"
     }
 end
 ```

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ If you use the server-side flow, Facebook will give you back a longer lived acce
 
 ## Supported Rubies
 
-- Ruby MRI (2.5, 2.6, 2.7, 3.0)
+- Ruby MRI (3.0, 3.1, 3.2 and 3.3)
 
 ## License
 

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -10,7 +10,7 @@ module OmniAuth
       class NoAuthorizationCodeError < StandardError; end
 
       DEFAULT_SCOPE = 'email'
-      DEFAULT_FACEBOOK_API_VERSION = 'v5.0'.freeze
+      DEFAULT_FACEBOOK_API_VERSION = 'v19.0'.freeze
 
       option :client_options, {
         site: "https://graph.facebook.com/#{DEFAULT_FACEBOOK_API_VERSION}",

--- a/omniauth-facebook.gemspec
+++ b/omniauth-facebook.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'omniauth-oauth2', '>= 1.2', '< 3'
+  s.add_runtime_dependency 'bigdecimal'
 
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
omniauth-facebook still uses Graph API version 5.0 as the default, which was shut off in [February 2022](https://developers.facebook.com/docs/graph-api/changelog/version5.0).
The current API version is [v19.0](https://developers.facebook.com/docs/graph-api/changelog). A [quick google search](https://www.google.com/search?client=safari&rls=en&q=%22oauth%22+site%3Ahttps%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fgraph-api%2Fchangelog%2F&ie=UTF-8&oe=UTF-8) didn't yield any changes to the OAuth part of the API. So I assume it's safe to use the current version of the API.
#374 addressed the problem already.
On the side I updated the CI test matrix and removed all [unmaintained Ruby versions](https://www.ruby-lang.org/en/downloads/).