### PR TITLE
Update default API version to v24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changes:
 
-  - bumped version of FB Graph API to v19.0
+  - bumped version of FB Graph API to v24.0
 
 ## 9.0.0 (2021-10-25)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ end
 
 ### API Version
 
-OmniAuth Facebook uses versioned API endpoints by default (current v19.0). You can configure a different version via `client_options` hash passed to `provider`, specifically you should change the version in the `site` and `authorize_url` parameters. For example, to change to v20.0 (assuming that exists):
+OmniAuth Facebook uses versioned API endpoints by default (current v24.0). You can configure a different version via `client_options` hash passed to `provider`, specifically you should change the version in the `site` and `authorize_url` parameters. For example, to change to v20.0 (assuming that exists):
 
 ```ruby
 use OmniAuth::Builder do

--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -10,7 +10,7 @@ module OmniAuth
       class NoAuthorizationCodeError < StandardError; end
 
       DEFAULT_SCOPE = 'email'
-      DEFAULT_FACEBOOK_API_VERSION = 'v19.0'.freeze
+      DEFAULT_FACEBOOK_API_VERSION = 'v24.0'.freeze
 
       option :client_options, {
         site: "https://graph.facebook.com/#{DEFAULT_FACEBOOK_API_VERSION}",


### PR DESCRIPTION
**Upgrade Facebook Graph API version from v19.0 to v24.0**

This pull request updates the default Facebook Graph API version used by the `omniauth-facebook` gem from **v19.0** to the latest version, **v24.0**.

The main motivation for this upgrade is to ensure the application's long-term stability and security by moving off the older version (v19.0, available until May 21, 2026) and aligning with the current API standard.

Reference: [Facebook Graph API v24.0 Changelog](https://developers.facebook.com/docs/graph-api/changelog/version24.0/)